### PR TITLE
Adds Go example

### DIFF
--- a/channel_integration/go/README.md
+++ b/channel_integration/go/README.md
@@ -1,54 +1,38 @@
-# GitHub Issues - Channel Integration with Python
+# GitHub Issues - Channel Integration with Go
 
 We can use Twist to create a new channel integration that interfaces with GitHub webhooks. The outcome we should expect from this example is:
 
 > When a new GitHub issue is created, it should post a relevant Twist thread to a channel that contains information about the issue.
 
 ## Prerequisites
-You'll need to ensure that [Python 2.x >](https://www.python.org/) is installed on your machine. You can download the latest current version on the website or by using [Homebrew](https://brew.sh)/[Chocolatey](https://chocolatey.org).
+To get it up and running you have to [install go](https://golang.org/), no external packages are needed.
 
 We'll also be using [ngrok](https://ngrok.com/) for this project. You can download the binary from [the website](https://ngrok.com/), `npm` or another method of your choosing.
 
 ## New Project
-Start off by creating a new Python and Flask application.
 
-To create a new Python project, run the following in your terminal:
+For this example, just create a file named `main.go`.
 
-```bash
-# Create a new directory
-$ mkdir twist-github-issues
+We can then set up a listen server with `net\http`:
 
-# Change directory
-$ cd twist-github-issues
-
-# Initiate a new Node project
-$ touch flask-github.py
-
-# Install the required dependencies
-$ pip install -r requirements.txt
-```
-
-We can then set up a listen server with Flask:
-
-```python
-# -*- coding: utf-8 -*-
-from flask import Flask
-from flask import jsonify
-from flask import request
-import requests, json
-
-app = Flask(__name__)
-
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+```go
+func main() {
+	log.Println("Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)")
+	log.Fatal(http.ListenAndServe(":5000", nil))
+}
 ```
 
 Next, we'll define a new route that our webhook will point at:
 
-```python
-@app.route('/issue', methods=['POST'])
-def incoming():
+```go
+func issuesHandler(w http.ResponseWriter, r *http.Request) {
   # TODO
+}
+
+func main() {
+	http.HandleFunc("/issues", issuesHandler)
+	...
+}
 ```
 
 Our application wants to listen for user events on GitHub (such as making a new issue) and then perform an action on Twist. This means we'll need to use `ngrok` to _expose_ our application and plug this into the integration over at [Twist](https://twistapp.com).
@@ -88,13 +72,12 @@ Using a new terminal window (with our server running) run the following command:
 
 ```$ ngrok http 5000```
 
-This starts a HTTP tunnel on based on our Python application that's running on port `5000`.
+This starts a HTTP tunnel on based on our Node application that's running on port `5000`.
 
-_Why this port? It's the one we told Flask we wanted our server to listen on:_
+_Why this port? It's the one we started our HTTP server to listen on:_
 
-```python
-if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+```go
+  http.ListenAndServe(":5000", nil)
 ```
 
 Copy the forwarding URL from your terminal, _with the free version of `ngrok`, this will be different each time the `ngrok` command is ran_. We can then place this inside of our Twist Integration under the 'Outgoing webhook URL' inside of the webhook section.
@@ -103,29 +86,46 @@ Ensure you use the HTTPS link and add the `/issue` route, for example, `https://
 
 ## GitHub Webhooks
 
-We can set up GitHub webhooks by navigating to our GitHub repository -> Settings -> Webhooks and then selecting 'Add webhook'. 
+We can set up GitHub webhooks by navigating to our GitHub repository -> Settings -> Webhooks and then selecting 'Add webhook'.
 
 Similar to our Twist integration, we'll add the URL from `ngrok` here as the Payload URL: https://53325f4d.ngrok.io/issue. For content type, select `application/json` and then we can simply add a word of our choosing within the secret box.
 
 We're then asked _Which events would you like to trigger this webhook?_ As we're simply looking for Issues only, select `Let me select individual events` and then tick `Issues`. To finish this, select _Add webhook_ you'll be able to see this in the dashboard.
 
 # Integration
-Everything is now in place to handle webhooks from GitHub. Let's modify our Node application to handle this.
+Everything is now in place to handle webhooks from GitHub. Let's modify our Go application to handle this.
 
 Firstly, we'll need to determine whether the incoming POST request is _from GitHub_, for this example, we've elected to do a simple check for the delivery ID from within the headers. Also, when debugging we may get an `event_type` payload with the value of `ping`, so we'll firstly check for this and respond with `pong`:
 
-```python
-@app.route('/issue', methods=['POST'])
-def incoming():
-    data = request.get_json()
-    github_id = request.headers.get('X-GitHub-Delivery')
+```go
+type reply struct {
+	Content string `json:"content"`
+}
 
-    if github_id is None:
-        event_type = data['body']['event_type']
-        if event_type is not None and event_type == 'ping':
-            return jsonify({'content': 'pong'})
-    else:
-        return jsonify({'content': 'Hello World'})
+func issuesHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, fmt.Sprintf("Method %s is not allowed.", r.Method), http.StatusMethodNotAllowed)
+		return
+	}
+
+	gh := r.Header.Get("X-Github-Delivery")
+	if gh == "" {
+		handlePing(w, r)
+		return
+  }
+}
+
+func handlePing(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+
+	eventType := r.FormValue("event_type")
+	if eventType == "ping" {
+		setResponse(w, reply{Content: "pong"})
+	}
+}
 ```
 
 If we now create an issue inside of the repository, we can then navigate back to our webhook and see `Recent Deliveries`. You'll be able to select a request that was made due to the open issue and see both the request and response data. You can see the entire payload from within this view and more importantly, **redeliver** the request and this means we don't have to keep creating issues each time we want to test our webhook.
@@ -134,38 +134,52 @@ If we now create an issue inside of the repository, we can then navigate back to
 
 Everything is in place to post Twist threads based off GitHub issues. Inside of our the overview of your newly installed integration, copy the **Post content manually** URL and add it to the application for future use:
 
-```python
-twist_url =
-  'https://twistapp.com/api/v2/integration_incoming/post_data?install_id=1234&install_token=01234_56a7b89c012345678de9012f345678ab';
+```Go
+twistURL = "https://twistapp.com/api/v2/integration_incoming/post_data?install_id=1234&install_token=01234_56a7b89c012345678de9012f345678ab"
 ```
 
 We can now create a new Twist thread whenever the issue comes in from the GitHub repository. We'll need to create a payload to send to Twist that contains information such as the `title` and post `content`, next, the payload can be sent using the `twist_url` that we created a moment ago:
 
-```python
-@app.route('/issue', methods=['POST'])
-def incoming():
-    data = request.get_json()
-    github_id = request.headers.get('X-GitHub-Delivery')
+```Go
+type twistData struct {
+	Title   string `json:"title"`
+	Content string `json:"content"`
+}
 
-    if github_id is None:
-        event_type = data['body']['event_type']
-        if event_type is not None and event_type == 'ping':
-            return jsonify({'content': 'pong'})
-    else:
-        repo_name = data['repository']['name']
-        issue_name = data['issue']['title']
-        issue_number = data['issue']['number']
-        body = data['issue']['body']
-        link = data['issue']['html_url']
+type issue struct {
+	Action string `json:"action"`
+	Issue  struct {
+		HTMLURL string `json:"html_url"`
+		Number  int    `json:"number"`
+		Title   string `json:"title"`
+		Body    string `json:"body"`
+	} `json:"issue"`
+	Repository struct {
+		Name string `json:"name"`
+	} `json:"repository"`
+}
 
-        title = "{0} - #{1} {2}".format(repo_name, issue_number, issue_name)
-        content = "**Body:** \n{0}\n\n**Link**:\n [GitHub Issue]({1})".format(
-            body, link)
+func issuesHandler(w http.ResponseWriter, r *http.Request) {
+	...
+	var data issue
+	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
 
-        twist_data = json.dumps({'title': title, 'content': content})
+	title := fmt.Sprintf("%s - #%d %s", data.Repository.Name, data.Issue.Number, data.Issue.Title)
+	content := fmt.Sprintf("**Body:** \n%s\n\n**Link**:\n [GitHub Issue](%s)", data.Issue.Body, data.Issue.HTMLURL)
 
-        res = requests.post(twist_url, twist_data)
-        return jsonify(twist_data)
+	payload, err := json.Marshal(twistData{title, content})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	resp, err := http.Post(twistURL, "application/json", bytes.NewBuffer(payload))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 ```
 
 If we check our channel, you should see that the Twist thread mirrors the GitHub issue! 😄

--- a/channel_integration/go/main.go
+++ b/channel_integration/go/main.go
@@ -1,0 +1,105 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+)
+
+const (
+	twistURL = "https://twistapp.com/api/v2/integration_incoming/post_data?install_id=71554&install_token=71554_b818c7fe1fee02a567cf87471cd8c287"
+)
+
+type reply struct {
+	Content string `json:"content"`
+}
+
+type twistData struct {
+	Title   string `json:"title"`
+	Content string `json:"content"`
+}
+
+type issue struct {
+	Action string `json:"action"`
+	Issue  struct {
+		HTMLURL string `json:"html_url"`
+		Number  int    `json:"number"`
+		Title   string `json:"title"`
+		Body    string `json:"body"`
+	} `json:"issue"`
+	Repository struct {
+		Name string `json:"name"`
+	} `json:"repository"`
+}
+
+func setResponse(w http.ResponseWriter, r reply) {
+	js, err := json.Marshal(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(js)
+}
+
+func handlePing(w http.ResponseWriter, r *http.Request) {
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+
+	eventType := r.FormValue("event_type")
+	if eventType == "ping" {
+		setResponse(w, reply{Content: "pong"})
+	}
+}
+
+func issuesHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, fmt.Sprintf("Method %s is not allowed.", r.Method), http.StatusMethodNotAllowed)
+		return
+	}
+
+	gh := r.Header.Get("X-Github-Delivery")
+	if gh == "" {
+		handlePing(w, r)
+		return
+	}
+
+	var data issue
+	if err := json.NewDecoder(r.Body).Decode(&data); err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+
+	title := fmt.Sprintf("%s - #%d %s", data.Repository.Name, data.Issue.Number, data.Issue.Title)
+	content := fmt.Sprintf("**Body:** \n%s\n\n**Link**:\n [GitHub Issue](%s)", data.Issue.Body, data.Issue.HTMLURL)
+
+	payload, err := json.Marshal(twistData{title, content})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	resp, err := http.Post(twistURL, "application/json", bytes.NewBuffer(payload))
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	tr, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Printf(err.Error())
+		return
+	}
+	log.Printf("\n%#v", string(tr))
+}
+
+func main() {
+	http.HandleFunc("/issues", issuesHandler)
+	log.Println("Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)")
+	log.Fatal(http.ListenAndServe(":5000", nil))
+}

--- a/slash_integration/go/README.md
+++ b/slash_integration/go/README.md
@@ -1,0 +1,41 @@
+Appear.in with Go
+====================
+
+This is a simple implementation of a slash integration to create a link
+to [appear.in](https://appear.in) when the slash command is called with an
+argument.
+
+Usage
+-----
+
+`/slash username`
+
+Will change the text to `https://appear.in/username`
+
+Implementation
+--------------
+
+It uses Go to implement a simple server to listen to the requests.
+
+To get it up and running you have to [install go](https://golang.org/) and run the server, no external packages are needed:
+
+    go run main.go
+
+It should run the server and display some debugging information like this:
+
+    2018/08/28 23:19:30 Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)
+
+Testing the integration 
+-----------------------
+
+We recommend to use [ngrok](https://ngrok.com) to tunnel external requests to
+your own local server. It already provides HTTPS for your integration out of the
+box. Please read [their documentation](https://ngrok.com/docs) to know how to
+install and configure it.
+
+When installed, run it pointing to the port your server is running:
+
+    ngrok http 5000
+
+It will give you the https address to use as your **Outgoing webhook URL** (you
+can create it [here](https://twistapp.com/integrations/build)).

--- a/slash_integration/go/main.go
+++ b/slash_integration/go/main.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+)
+
+type reply struct {
+	Content string `json:"content"`
+}
+
+func setResponse(w http.ResponseWriter, r reply) {
+	js, err := json.Marshal(r)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(js)
+}
+
+func appearHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != "POST" {
+		http.Error(w, fmt.Sprintf("Method %s is not allowed.", r.Method), http.StatusMethodNotAllowed)
+		return
+	}
+
+	if err := r.ParseForm(); err != nil {
+		http.Error(w, err.Error(), http.StatusUnprocessableEntity)
+		return
+	}
+
+	eventType := r.FormValue("event_type")
+	switch eventType {
+	case "ping":
+		setResponse(w, reply{Content: "pong"})
+	default:
+		arg := r.FormValue("command_argument")
+		url := fmt.Sprintf("https://appear.in/%s", arg)
+		setResponse(w, reply{Content: url})
+	}
+}
+
+func main() {
+	http.HandleFunc("/appear", appearHandler)
+	log.Println("Running on http://0.0.0.0:5000/ (Press CTRL+C to quit)")
+	log.Fatal(http.ListenAndServe(":5000", nil))
+}


### PR DESCRIPTION
I was playing with the API and took the liberty to port the examples to Go. Both examples are fully working.

For simplicity purposes I thought about removing the error handling as they get quite verbose in Go, but it is not a good practice, so I decided to handle everything and also parse the json using structs.

I found some typos in the Python example README and fixed them.

I'm not sure if its interesting keeping this examples in go, but it was fun to write 🤣 thanks.

![image](https://user-images.githubusercontent.com/1084729/44769683-d6cd5080-ab3b-11e8-980a-aa6256cdffcf.png)
