### PR TITLE
Add links to go example on the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ Examples
 ### Node
 * [GitHub issue -> Twist thread](channel_integration/node/)
 
+### Go
+* [GitHub issue -> Twist thread](channel_integration/go/)
+
 ## Slash Integration
 
 ### Python
@@ -22,3 +25,6 @@ Examples
 
 ### Node
 * [Appear.in slash integration](slash_integration/node/)
+
+### Go
+* [Appear.in slash integration](slash_integration/go/)


### PR DESCRIPTION
In my previous PR I forgot to update the README to link to the go examples.